### PR TITLE
refactor : reservation 엔티티의 공연명, 공연날짜 컬럼 삭제

### DIFF
--- a/src/main/java/com/starter/performance/controller/ReservationController.java
+++ b/src/main/java/com/starter/performance/controller/ReservationController.java
@@ -45,7 +45,7 @@ public class ReservationController {
                 savedReservation.getPerformanceSchedule().getPerformance().getName(),
                 savedReservation.getReservedTicketNum(),
                 savedReservation.getReservationStatus(),
-                savedReservation.getPerformanceDate(),
+                savedReservation.getPerformanceSchedule().getPerformanceDate(),
                 savedReservation.getReservationDate()
             ))
             .build();

--- a/src/main/java/com/starter/performance/domain/Reservation.java
+++ b/src/main/java/com/starter/performance/domain/Reservation.java
@@ -34,18 +34,12 @@ public class Reservation {
     @JoinColumn(name = "performance_schedule")
     private PerformanceSchedule performanceSchedule;
 
-    @Column(nullable = false, length = 100)
-    private String performanceName;
-
     @Column(nullable = false)
     private Integer reservedTicketNum;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 30)
     private ReservationStatus reservationStatus;
-
-    @Column(nullable = false)
-    private LocalDateTime performanceDate;
 
     @Column(nullable = false)
     private LocalDateTime reservationDate;

--- a/src/main/java/com/starter/performance/service/impl/ReservationServiceImpl.java
+++ b/src/main/java/com/starter/performance/service/impl/ReservationServiceImpl.java
@@ -91,8 +91,6 @@ public class ReservationServiceImpl implements ReservationService {
         Reservation reservation = Reservation.builder()
             .member(member)
             .performanceSchedule(performanceSchedule)
-            .performanceName(performanceSchedule.getPerformance().getName())
-            .performanceDate(performanceSchedule.getPerformanceDate())
             .reservedTicketNum(Integer.parseInt(dto.getReservedTicketNum()))
             .reservationStatus(ReservationStatus.YES)
             .reservationDate(LocalDateTime.now())
@@ -110,7 +108,7 @@ public class ReservationServiceImpl implements ReservationService {
 
         String subject = "[공연 예매 사이트] 예매가 무사히 완료되었습니다.";
         StringBuilder text = new StringBuilder();
-        text.append(email).append("님의 [").append(savedReservation.getPerformanceName())
+        text.append(email).append("님의 [").append(savedReservation.getPerformanceSchedule().getPerformance().getName())
             .append("] 예매가 무사히 완료되었습니다. 자세한 내용은 예매목록보기에서 확인할 수 있습니다.");
 
         mailComponent.sendMail(email, subject, text);
@@ -133,7 +131,7 @@ public class ReservationServiceImpl implements ReservationService {
                 savedReservation.getPerformanceSchedule().getPerformance().getName(),
                 savedReservation.getReservedTicketNum(),
                 savedReservation.getReservationStatus(),
-                savedReservation.getPerformanceDate(),
+                savedReservation.getPerformanceSchedule().getPerformanceDate(),
                 savedReservation.getReservationDate());
 
             dtoList.add(dto);
@@ -178,7 +176,7 @@ public class ReservationServiceImpl implements ReservationService {
                 reservation.getPerformanceSchedule().getPerformance().getName(),
                 reservation.getReservedTicketNum(),
                 reservation.getReservationStatus(),
-                reservation.getPerformanceDate(),
+                reservation.getPerformanceSchedule().getPerformanceDate(),
                 reservation.getReservationDate()
             ))
             .build();
@@ -222,7 +220,7 @@ public class ReservationServiceImpl implements ReservationService {
                 reservation.getPerformanceSchedule().getPerformance().getName(),
                 reservation.getReservedTicketNum(),
                 reservation.getReservationStatus(),
-                reservation.getPerformanceDate(),
+                reservation.getPerformanceSchedule().getPerformanceDate(),
                 reservation.getReservationDate()
             ))
             .build();


### PR DESCRIPTION
### What is the PR type?
- [ ] : feature
- [x] : refactor
- [ ] : bug
- [ ] : documentation
- [ ] : chore
- [ ] : etc

### What does this PR do?
예매 목록을 조회할 때 예매(reservation) 테이블에서 공연명, 공연날짜를 가져오도록 처음에 설정하여 
예매 테이블에 공연명, 공연날짜 컬럼을 추가하였음.
그러나 이 경우 공연명과 공연날짜가 변경되었을 때 예매 테이블에 내용들도 변경해야하는 번거로움이 있음.

이에 예매 테이블말고 "예매", "예매 확인 메일", "예매 목록 조회", "예매 수정", "예매 취소" 기능 요청 시
필요한 정보들(공연명, 공연날짜)을 각 테이블에서 가져오도록 변경.

### What will do next?